### PR TITLE
Update init.qcom-common.rc to support usb-to-ethernet adapters

### DIFF
--- a/rootdir/etc/init.qcom-common.rc
+++ b/rootdir/etc/init.qcom-common.rc
@@ -488,12 +488,22 @@ service dhcpcd_wlan0 /system/bin/dhcpcd -aABDKL
     disabled
     oneshot
 
+service dhcpcd_eth0 /system/bin/dhcpcd -aABDKL
+    class late_start
+    disabled
+    oneshot
+
 service dhcpcd_p2p /system/bin/dhcpcd -aABKL
     class late_start
     disabled
     oneshot
 
 service iprenew_wlan0 /system/bin/dhcpcd -n
+    class late_start
+    disabled
+    oneshot
+
+service iprenew_eth0 /system/bin/dhcpcd -n
     class late_start
     disabled
     oneshot


### PR DESCRIPTION
In both Oppo Find 7 (find7/find7s) and OnePlus One (bacon) devices, it is possible to add the support for an usb-to-ethernet adapter, simply adding some lines in this file. These are the lines I've added:

service dhcpcd_eth0 /system/bin/dhcpcd -aABDKL
class late_start
disabled
oneshot

service iprenew_eth0 /system/bin/dhcpcd -n
class late_start
disabled
oneshot

I've already proposed this change on Jira (https://jira.cyanogenmod.org/browse/CYAN-6571).
